### PR TITLE
[GH-9] Removed double quotes. Bug fix. Compile switch between prod & dev.

### DIFF
--- a/compile
+++ b/compile
@@ -28,17 +28,22 @@ src/acts/*
 src/demo.lua
 "
 
-CODE_STORE=build\\/prd-store.p8
-WRITER_STORE=prd-store.p8
-
-echo "Cleaning build directory..."
+echo "* Cleaning build directory..."
 rm -r build
 mkdir -p build
 
-echo "Running the lua minifier..."
-cat src/dev-boot.lua $files_in_order | ./pico_minifier -d                                            > build/dev-code.lua
-cat src/prd-boot.lua $files_in_order | ./pico_minifier -i src/prd-writer.lua -o build/prd-writer.lua > build/prd-code.lua
+if [ "$1" == "-p" ]; then
+   echo "* Running the prd-mode minifier..."
+   cat src/prd-boot.lua $files_in_order | ./pico_minifier -i src/prd-writer.lua -o build/writer.lua > build/code.lua
 
-sed -i "s/STORE_FILEPATH/$CODE_STORE/g" build/prd-code.lua
-echo "Writing boot cartridge with pico8..."
-pico8 -x build/prd-writer.lua -p $WRITER_STORE
+   # Not in minifier, because it doesn't need to know file paths.
+   sed -i "s/STORE_FILEPATH/build\\/store.p8/g" build/code.lua
+
+   echo "* Running prd-mode pico-8 cstore..."
+   pico8 -x build/writer.lua -p store.p8
+else
+   echo "* Running the dev-mode minifier..."
+   cat src/dev-boot.lua $files_in_order | ./pico_minifier -d > build/code.lua
+fi
+
+echo "* Done!"

--- a/pico_minifier
+++ b/pico_minifier
@@ -217,14 +217,17 @@ if (not $dev_mode) {
 
 my ($strings, $contents) = multiline_string_replace(join("\n", @lines));
 
+# Ztable doesn't use the quotes in the string data, so remove them.
+$strings =~ s/"//g;
+
 sub length_in_graphemes {
     my $word = shift;
     my $length = () = $word =~ m/\X/g;
     return $length;
 }
 
-my $strings_len = length_in_graphemes($strings)-4; # -4 for '[[' and ']]'
-$contents =~ s/ZTABLE_STRINGS_LEN/$strings_len/gme;
+my $strings_len = length_in_graphemes($strings); # -4 for '[[' and ']]'
+$contents =~ s/ZTABLE_STRINGS_LEN/$strings_len+1/gme;
 $contents =~ s/ZTABLE_STRINGS/$strings/gme;
 
 if ($input_file ne "" and $output_file ne "") {
@@ -232,7 +235,6 @@ if ($input_file ne "" and $output_file ne "") {
    open(my $dst, ">:utf8", $output_file) or die "Unable to create file \"$output_file\"\n";
 
    my $src_content = do { local $/; <$src> };
-   $src_content =~ s/ZTABLE_STRINGS_LEN/$strings_len/gme;
    $src_content =~ s/ZTABLE_STRINGS/$strings/gme;
 
    close $src;

--- a/src/prd-boot.lua
+++ b/src/prd-boot.lua
@@ -1,5 +1,5 @@
 -- String data used throughout the cartridge.
-reload(0, 0, ZTABLE_STRINGS_LEN, "STORE_FILEPATH")
+reload(0, 0, 0x4300, "STORE_FILEPATH")
 
 g_gunvals_raw = ""
 for i=1,ZTABLE_STRINGS_LEN do

--- a/src/prd-writer.lua
+++ b/src/prd-writer.lua
@@ -9,5 +9,4 @@ cstore(0, 0, #str, filepath)
 
 printh("len is: "..#str)
 printh("filepath is: "..filepath)
-printh("passed len is ZTABLE_STRINGS_LEN")
 flip()

--- a/watcher
+++ b/watcher
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 # pico watch, by Alan Morgan
 
-FILE='compile'
-if [[ $# -eq 1 ]]; then
-   FILE=$1
-fi
-echo "Using file '$FILE'"
+echo "** Using argument '$1'."
 
 inotifywait -e close_write,moved_to,create -mr ./src |
 while read -r directory; do
-  echo "'$directory' was changed."
-  ./$FILE
+  echo "** '$directory' was changed, so let's compile this thing!"
+  ./compile $1
+  echo
 done

--- a/zeldo.p8
+++ b/zeldo.p8
@@ -3,8 +3,7 @@ version 29
 __lua__
 -- that story about zeldo
 -- amorg
---#include build/dev-code.lua
-#include build/prd-code.lua
+#include build/code.lua
 
 __gfx__
 00000000000000000000000000000000000000000000000000000000000000001500111111110051015dcc6cccccd510c600c600000000001111111111111111


### PR DESCRIPTION
The case is for removing the double quotes, but there was a slight bug
from the previous case. The bug was an off by one error, because the
program was loading `[0 - #x)`, but reading `[1 - #x]`. I fixed the bug
while keeping the token count static by explicitly specifying 0x4300.

I also changed the dev/prod behaviour. It's more expensive to build the
prod game, so the compile and watcher commands will run dev by default.
If you want it to run prod instead, specify a `-p`. This also means I
can use the same code filename and the `zeldo.p8` file doesn't have to
be changed anymore.