### PR TITLE
[GH-14] Very easy to make navy not turn.

### DIFF
--- a/src/acts/people.lua
+++ b/src/acts/people.lua
@@ -2,6 +2,7 @@
 create_actor([[navy_blocking;2;nnpc,mem_dep]], [[
    name:"navy";
    sind:97;mem_loc:NAVY_OUT;
+   u:nf;
    x:@1;y:@2;interactable_trigger:@3;pause_end:@4;
 ]],function(a)
    if zdget'HAS_BOOMERANG' then


### PR DESCRIPTION
Just had to overwrite the look_at_player function. It didn't cost any
tokens either.